### PR TITLE
Modify apparently incorrect test

### DIFF
--- a/samples/retrieve_related_videos.py
+++ b/samples/retrieve_related_videos.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
         for relatedvideos in youtube.iterate_related_videos(videoId,maxCount):
             for item in relatedvideos['items']:
                 rvideoId, rtitle = item['id']['videoId'],item['snippet']['title']
-                if rvideoId not in liked and rvideoId not in recommended:
+                if rvideoId not in liked:
                     if rvideoId not in recommended:
                         recommended[rvideoId] = {"title" : rtitle,"count" : 1}
                     else:


### PR DESCRIPTION
The original line 46 contained the test

    if rvideoId not in liked and rvideoId not in recommended:

For line 47 to execute at all, therefore, `rvideoId not in recommended` must be true. It follows that the test in line 47 will always succeed, and that the incrementation logic in line 50 can never execute. It seems unlikely this was intentional.